### PR TITLE
auto publish DA to community registry + rename tile

### DIFF
--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -7,7 +7,7 @@ offerings:
     offering_id: 5a6c3a87-d9e8-437c-a524-bfdf4d18165a
     variations:
       - name: standard
-        mark_ready: false
+        mark_ready: true
         install_type: fullstack
         scc:
           instance_id: 1c7d5f78-9262-44c3-b779-b28fe4d88c37

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -2,7 +2,7 @@
   "products": [
     {
       "name": "deploy-arch-ibm-iam-access-group",
-      "label": "Cloud Automation for Access Management",
+      "label": "Cloud automation for access management",
       "product_kind": "solution",
       "tags": [
         "ibm_created",


### PR DESCRIPTION
### Description

- auto publish DA to community registry
- Renamed the tile to `Cloud automation for access management`. There is no service name in the offering name, so none of the letters should be capitalised. (I already update the offering manually in the catalog)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
